### PR TITLE
Fix/cpim handling from dryrun 1

### DIFF
--- a/outbound-hook.php
+++ b/outbound-hook.php
@@ -29,15 +29,17 @@ if (isset($event->extensionUUID)) {
     // Web UI payload (Ian's webtexting)
     $to = $event->to;
     $contentType = $event->contentType;
-    $body = urldecode($event->body);
-    $dedupeID = urldecode($event->id);
+    $body = rawurldecode($event->body);
+    $dedupeID = rawurldecode($event->id);
     $extensionUUID = $event->extensionUUID;
 } else {
     // FreeSWITCH event payload (from chatplan Lua via mod_curl)
     // extension_uuid set by chatplan: ${user_data(${from_user}@${from_host} var extension_uuid)}
+    // Note: rawurldecode (RFC 3986) preserves literal `+` in CPIM Content-Type
+    // (e.g., application/vnd.gsma.rcs-ft-http+xml). urldecode would mangle to space.
     $to = $event->to_user;
     $contentType = isset($event->type) ? $event->type : 'text/plain';
-    $body = isset($event->_body) ? urldecode($event->_body) : '';
+    $body = isset($event->_body) ? rawurldecode($event->_body) : '';
     $dedupeID = isset($event->{'sip_h_X-Message-ID'}) ? $event->{'sip_h_X-Message-ID'} : uuid();
     $extensionUUID = $event->extension_uuid;
 }

--- a/threadlist.php
+++ b/threadlist.php
@@ -256,7 +256,7 @@ if ($_SESSION['user']['multiple_wt_extensions']) {
 
 ?>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.3/dist/umd/popper.min.js"></script>
-<script src="js/webtexting.umd.js"></script>
+<script src="js/webtexting.umd.js?v=<?php echo filemtime(__DIR__ . '/js/webtexting.umd.js'); ?>"></script>
 <script type="text/javascript">
 window.notification_data = <?php echo json_encode(array("extension_uuid" => $extension['extension_uuid'])); ?>;
 


### PR DESCRIPTION
Add a cachebuster on webtexting.umd.js, and switch urldecode to rawurldecode (RFC 3986)