### PR TITLE
Extract bodyText for text/plain CPIM messages

### DIFF
--- a/frontend/lib/CPIM.ts
+++ b/frontend/lib/CPIM.ts
@@ -49,6 +49,12 @@ export class CPIM {
             cpim.fileURL = data.getAttribute("url");
         }
 
+        // text/plain bodyText extraction — must match behavior of the equivalent PHP CPIM parser
+        const innerType = (cpim.getHeader('content-type') || '').toLowerCase();
+        if (innerType.startsWith('text/plain')) {
+            cpim.bodyText = parts[2];
+        }
+
         return cpim;
     }
 


### PR DESCRIPTION
Phase 2's Messages::IncomingMMS now splits inbound MMS into separate CPIM rows for the file-transfer payload and the inline text caption (text/plain body). The CPIM class declares bodyText but fromString never populated it, so the web UI received the caption row but had nothing to render.

Adds bodyText extraction when the inner Content-Type is text/plain. Discovered during sfo prod deploy May 7 2026; validated end-to-end via in-place perl patch on the deployed bundle, then mirrored here for the next CI rebuild.